### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/c/ast.c
+++ b/src/c/ast.c
@@ -134,7 +134,7 @@ void display_parse_error(struct ast_t *a, const char *type_strings[]) {
         case AST_ERROR:
         {
             struct ast_error_t *error = a->data.error;
-            printf("parse error: failed to match '%s' at line=%d, col=%d, pos=%d\n",
+            printf("parse error: failed to match '%s' at line=%zu, col=%zu, pos=%zu\n",
                    type_strings[error->nt], error->line, error->col, error->pos);
             break;
         }

--- a/src/c/cache.c
+++ b/src/c/cache.c
@@ -48,7 +48,7 @@ size_t cache_hash_key(struct cache_key_t *key) {
  * Doesn't consider hash collisions.
  */
 size_t cache_start_pos(struct ht_t *v, struct cache_key_t *key) {
-    return abs(cache_hash_key(key) % v->capacity);
+    return cache_hash_key(key) % v->capacity;
 }
 
 
@@ -73,7 +73,7 @@ size_t cache_final_pos(struct ht_t *v, struct cache_key_t *key) {
         }
 
         offset++;
-        pos = abs((pos + offset * offset) % v->capacity);
+        pos = (pos + offset * offset) % v->capacity;
         pair = v->pairs[pos];
     }
 }

--- a/src/c/lt.c
+++ b/src/c/lt.c
@@ -22,7 +22,7 @@ size_t lt_hash_key(size_t key) {
  * Doesn't consider hash collisions.
  */
 size_t lt_start_pos(struct ht_t *v, size_t key) {
-    return abs(lt_hash_key(key) % v->capacity);
+    return lt_hash_key(key) % v->capacity;
 }
 
 
@@ -46,7 +46,7 @@ size_t lt_final_pos(struct ht_t *v, size_t key) {
         }
 
         offset++;
-        pos = abs((pos + offset * offset) % v->capacity);
+        pos = (pos + offset * offset) % v->capacity;
         pair = v->pairs[pos];
     }
 }


### PR DESCRIPTION
There are two warning types being addressed (the only two warnings in fact, well done!):
- abs(size_t) is a no-op
- printf format for size_t should be %zu rather than %d

https://stackoverflow.com/a/2524675
http://www.cplusplus.com/reference/cstdio/printf/
https://linux.die.net/man/3/printf
"z: A following integer conversion corresponds to a size_t or ssize_t argument."