### PR TITLE
Simplify build instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ docs/javadoc/
 lib/
 src/c/tests-build/
 tmp/
+bin/waxeye
+dist/

--- a/README.md
+++ b/README.md
@@ -76,17 +76,7 @@ Building from Source
 
 1. Install [Racket](http://racket-lang.org)
 
-2. Install Waxeye's backend for Scheme.
-   * Unix and OSX
-
-     `sudo ln -s /usr/local/waxeye/src/scheme/waxeye /usr/local/racket/lib/racket/collects/`
-
-   * Windows
-
-     Copy the directory `src/scheme/waxeye` into your Racket `collects`
-     directory. For example, `C:\Program Files\Racket\collects`.
-
-3. Build Waxeye
+2. Build Waxeye
    * Unix and OSX
 
      `./build/unix`
@@ -96,8 +86,8 @@ Building from Source
      - If your Racket installation isn't `C:\Program Files\Racket`, then you
        will need to modify `build\exe.bat` to use the correct path.
 
-     - From your Waxeye installation directory, run the `build\exe.bat` script
-       in a command prompt.
+     - Run the `build\exe.bat` script. The `waxeye.exe` executable
+       will be saved to the directory you run the script from.
 
 Running tests
 -------------

--- a/build/boot
+++ b/build/boot
@@ -1,3 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+# Generates a parser for the Waxeye grammar.
+source "${BASH_SOURCE[0]%/*}/env.sh"
 
-./build/waxeye -g scheme src/waxeye/ -c src/waxeye/header.txt -p grammar grammars/waxeye.waxeye
+build/waxeye -g scheme src/waxeye/ -c src/waxeye/header.txt -p grammar grammars/waxeye.waxeye

--- a/build/env.sh
+++ b/build/env.sh
@@ -1,0 +1,3 @@
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"/..
+ROOT="$(pwd)"

--- a/build/exe.bat
+++ b/build/exe.bat
@@ -1,3 +1,4 @@
-C:\"Program Files\Racket\raco.exe" exe src\waxeye\waxeye.scm
-C:\"Program Files\Racket\raco.exe" distribute . src\waxeye\waxeye.exe
-DEL src\waxeye\waxeye.exe
+SET PLTCOLLECTS=";%~dp0..\src\scheme\"
+"C:\Program Files\Racket\raco.exe" exe "%~dp0..\src\waxeye\waxeye.scm"
+"C:\Program Files\Racket\raco.exe" distribute . "%~dp0..\src\waxeye\waxeye.exe"
+DEL "%~dp0..\src\waxeye\waxeye.exe"

--- a/build/make
+++ b/build/make
@@ -1,3 +1,4 @@
-#!/bin/sh
+#!/bin/bash
+source "${BASH_SOURCE[0]%/*}/env.sh"
 
-mzscheme -qt- build/build.scm $*
+racket -S src/scheme build/build.scm "$@"

--- a/build/unix
+++ b/build/unix
@@ -1,5 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+source "${BASH_SOURCE[0]%/*}/env.sh"
 
-raco exe -o waxeye src/waxeye/waxeye.scm
+PLTCOLLECTS=":${ROOT}/src/scheme/" raco exe -o waxeye src/waxeye/waxeye.scm
 raco distribute . waxeye
 rm waxeye

--- a/build/waxeye
+++ b/build/waxeye
@@ -1,3 +1,4 @@
-#!/bin/sh
+#!/bin/bash
+source "${BASH_SOURCE[0]%/*}/env.sh"
 
-mzscheme -t src/waxeye/waxeye.scm -- $*
+racket -S src/scheme ./src/waxeye/waxeye.scm "$@"


### PR DESCRIPTION
1. Do not require the user to copy Waxeye to the racket directory.
2. Make the build scripts runnable from any working directory.
   On Windows, you can now simply double-click `build/exe.bat`.
3. Use `racket` instead of `mzscheme`.
4. Use `#!/bin/bash` because POSIX shell is painful. Bash can be trivially installed on any unix distribution (and symlinked to `#!/bin/bash` if the default install location is different).