### PR TITLE
Fix JavaScript ParseError#toString

### DIFF
--- a/test/fixtures/env1.waxeye
+++ b/test/fixtures/env1.waxeye
@@ -24,4 +24,4 @@ Nums <= ? ( Int * ( WS : ',' WS Int ) )
 lc <: * ( 'a' | '\t' | '\n' | '\r' )
 
 # Unicode character classes
-Unicode <- [ﬆ-𝌆]
+Unicode <- [ﬆ-𝌆αβγ😃]

--- a/test/javascript/lib.js
+++ b/test/javascript/lib.js
@@ -44,31 +44,19 @@ TestEnv.prototype.match = function(nt, input) {
   return (new waxeye.WaxeyeParser(this.env, nt)).parse(input);
 };
 
-function codepointsToChars(cps) {
-  return cps.map(function(cp) {
-    return String.fromCodePoint(cp);
-  });
-}
-
-function charsToCodepoints(chars) {
-  return chars.map(function(c) {
-    return c.codePointAt(0);
-  });
-}
-
 function fromFixtureExpectationCharClasses(charClasses) {
-  if (typeof charClasses[0] === 'string') {
-    return charsToCodepoints(charClasses);
+  if (typeof charClasses === 'string') {
+    return charClasses.codePointAt(0);
   } else {
-    return charClasses.map(charsToCodepoints);
+    return charClasses.map(fromFixtureExpectationCharClasses);
   }
 }
 
 function toFixtureExpectationCharClasses(charClasses) {
-  if (typeof charClasses[0] === 'number') {
-    return codepointsToChars(charClasses);
+  if (typeof charClasses === 'number') {
+    return String.fromCodePoint(charClasses);
   } else {
-    return charClasses.map(codepointsToChars);
+    return charClasses.map(toFixtureExpectationCharClasses);
   }
 }
 

--- a/test/javascript/test-fixtures.json
+++ b/test/javascript/test-fixtures.json
@@ -333,11 +333,15 @@
   ["MatchError", ["match", "lc", "\n\n\nb"], ["ParseError", 3, 4, 0, ["lc"], [{ "type": "ErrChar", "arg": "a" }, { "type": "ErrChar", "arg": "\t" }, { "type": "ErrChar", "arg": "\n" }, { "type": "ErrChar", "arg": "\r" }]]],
   ["MatchError", ["match", "lc", "\n\na\naabaa"], ["ParseError", 6, 4, 2, ["lc"], [{ "type": "ErrChar", "arg": "a" }, { "type": "ErrChar", "arg": "\t" }, { "type": "ErrChar", "arg": "\n" }, { "type": "ErrChar", "arg": "\r" }]]],
 
-  ["Comment", "Unicode tests"],
-  ["MatchAST",["match","Unicode","ﬅ"],["ParseError",0,1,0,["Unicode"],[{"type":"ErrCC","arg":[["ﬆ","𝌆"]]}]]],
+  ["Comment","Unicode tests"],
+  ["MatchAST",["match","Unicode","ﬅ"],["ParseError",0,1,0,["Unicode"],[{"type":"ErrCC","arg":[["α","γ"],["ﬆ","𝌆"],"😃"]}]]],
   ["MatchAST",["match","Unicode","ﬆ"],["Tree","Unicode",[["Char","ﬆ"]]]],
   ["MatchAST",["match","Unicode","ﬕ"],["Tree","Unicode",[["Char","ﬕ"]]]],
   ["MatchAST",["match","Unicode","𝌅"],["Tree","Unicode",[["Char","𝌅"]]]],
   ["MatchAST",["match","Unicode","𝌆"],["Tree","Unicode",[["Char","𝌆"]]]],
-  ["MatchAST",["match","Unicode","𝌇"],["ParseError",0,1,0,["Unicode"],[{"type":"ErrCC","arg":[["ﬆ","𝌆"]]}]]]
+  ["MatchAST",["match","Unicode","𝌇"],["ParseError",0,1,0,["Unicode"],[{"type":"ErrCC","arg":[["α","γ"],["ﬆ","𝌆"],"😃"]}]]],
+  ["MatchAST",["match","Unicode","😃"],["Tree","Unicode",[["Char","😃"]]]],
+  ["MatchAST",["match","Unicode","α"],["Tree","Unicode",[["Char","α"]]]],
+  ["MatchAST",["match","Unicode","β"],["Tree","Unicode",[["Char","β"]]]],
+  ["MatchAST",["match","Unicode","γ"],["Tree","Unicode",[["Char","γ"]]]]
 ]


### PR DESCRIPTION
1. Fixes a bug in ParseError#toString that happened when converting charClasses with both ranges and chars.
2. Changes ParseError expected chars display to match the grammar file format.