### PR TITLE
Declare types for the automaton data structures

### DIFF
--- a/src/racket/waxeye/fa.rkt
+++ b/src/racket/waxeye/fa.rkt
@@ -3,17 +3,41 @@
 ;; Copyright (C) 2008-2010 Orlando Hill
 ;; Licensed under the MIT license. See 'LICENSE' for details.
 
-#lang racket/base
+#lang typed/racket/base
 (provide (all-defined-out))
 
-;; t - The transition cost
+; Union types for `edge.s` and `state` are currently necessary because the same types are used
+; in NFA, DFA, and the  intermediate states while converting NFA->DFA.
+
+(define-type NonTerminalName String)
+(define-type AutomatonIndex Integer)
+(define-type Wildcard 'wild)
+(define-type CharRange (Pairof Char Char))
+(define-type CharClass (Listof (U Char CharRange)))
+(define-type OptionalOrClosure 'e)
+(define-type Transition (U NonTerminalName AutomatonIndex Wildcard Char CharClass OptionalOrClosure))
+(define-type State (U AutomatonIndex state))
+(define-type AutomatonMode (U 'voidArrow 'pruneArrow 'leftArrow '& '!))
+
+;; t - Allowed transition
 ;; s - The state to transition to
 ;; v - If the result of the cost should be included in the tree
-(struct edge (t s v) #:mutable)
+(struct edge
+  ([t : Transition]
+   ; State in NFA, (Listof State) in DFA
+   [s : (U State (Listof State))]
+   [v : Boolean])
+  #:mutable)
 
-(struct state (edges match) #:mutable)
+(struct state
+  ([edges : (Listof edge)]
+   [match : Boolean])
+   #:mutable)
 
 ;; type - string if Non-Terminal
 ;; states - a vector of states
 ;; mode - the automaton mode
-(struct fa (type states mode))
+(struct fa
+  ([type : Symbol]
+   [states : (Vectorof state)]
+   [mode : AutomatonMode]))

--- a/src/waxeye/dfa.rkt
+++ b/src/waxeye/dfa.rkt
@@ -111,7 +111,7 @@
               (hash-set! state-table state-set state-count)
               (set! state-num state-count)
               (set! state-count (+ state-count 1))
-              (let ((new-state (state #f
+              (let ((new-state (state '()
                                       ;; Is our state-set an end state?
                                       (not (not (memf (lambda (a)
                                                         (state-match (vector-ref nfa a)))

--- a/src/waxeye/nfa.rkt
+++ b/src/waxeye/nfa.rkt
@@ -99,7 +99,7 @@
 
 
 (define (build-closure exp end)
-  (let* ((s (state #f #f))
+  (let* ((s (state '() #f))
          (e (build-states (car (ast-c exp)) s)))
     (set-state-edges! s (append (state-edges e) (list (edge 'e end is-void))))
     s))

--- a/src/waxeye/set.rkt
+++ b/src/waxeye/set.rkt
@@ -6,6 +6,8 @@
 #lang racket/base
 (provide subset?)
 
+; TODO: Looks like this function is never called? Investigate.
+
 ;; Is 'b' a subset of 'a'?
 (define (subset? a b)
   (if (null? b)


### PR DESCRIPTION
Unfortunately, this increases the executable size from 3MiB to 15MiB.
This is due to https://github.com/racket/racket/issues/1779