### PR TITLE
Add basic e2e test for the C runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 docs/javadoc/
 lib/
+src/c/libwaxeye.a
 src/c/tests-build/
 tmp/
 bin/waxeye

--- a/src/c/makefile
+++ b/src/c/makefile
@@ -6,8 +6,8 @@
 
 CLANG=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
 
-# The "-std=c99" argument is only needed to support gcc < v5.
-GCC=gcc -std=c99
+# The "-std=c11" argument is only needed to support gcc < v5.
+GCC=gcc -std=c11
 
 BASE_FLAGS=-Wall -Wextra -Wshadow -pedantic -I include
 FLAGS=$(BASE_FLAGS) -O3
@@ -108,8 +108,8 @@ debug-lib: clean-all
 	cp $(LIB_NAME) $(LIB_DIR)
 
 
-run: clean-all lib
-	$(GCC) $(FLAGS) parser.c run.c $(LIB) -o run
+display_ast: clean-all lib
+	$(GCC) $(FLAGS) $(PARSER_C) tests/display_ast.c $(LIB) -o $(DISPLAY_AST_OUT)
 
 
 debug: clean-all debug-lib

--- a/src/c/tests/display_ast.c
+++ b/src/c/tests/display_ast.c
@@ -5,6 +5,13 @@
  * Licensed under the MIT license. See 'LICENSE' for details.
  */
 
+// Reads and parses the input from stdin and prints the AST.
+// This is used to run e2e tests on the AST.
+// This file is copied to the build directory and compiled together with a parser at test time.
+
+#define _XOPEN_SOURCE 500  // for pclose
+
+#include <stdio.h>
 #include "parser.h"
 
 int main() {

--- a/test/bin/env.sh
+++ b/test/bin/env.sh
@@ -3,6 +3,12 @@ cd "$( dirname "${BASH_SOURCE[0]}" )"/../..
 
 source "${BASH_SOURCE%/*}/lib-waxeye.sh"
 
+# Path manipulation
+
+abspath() {
+  echo "$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
+}
+
 # Logging
 
 RED='\033[0;31m'

--- a/test/bin/lib-c.sh
+++ b/test/bin/lib-c.sh
@@ -1,0 +1,30 @@
+set -euo pipefail
+source "${BASH_SOURCE%/*}/lib-waxeye.sh"
+
+C_DEFAULT_PARSER_NAME=test
+
+build_c_parser() {
+  local -r grammar_path="${1:-./test/fixtures/env1.waxeye}"
+  local -r parser_name="${2:-$C_DEFAULT_PARSER_NAME}"
+  local -r parser_dir="$(c_parser_dir "$parser_name")"
+  rm -rf "$parser_dir"
+  mkdir -p "$parser_dir"
+  local -r abs_parser_dir="$(abspath "$parser_dir")"
+
+  run_waxeye -g c "$parser_dir" "$grammar_path" > /dev/null
+
+  PARSER_C="${abs_parser_dir}/parser.c" \
+  DISPLAY_AST_OUT="${abs_parser_dir}/display_ast" \
+  C_INCLUDE_PATH=":$abs_parser_dir" \
+    make -s --directory=src/c display_ast
+}
+
+c_parser_dir() {
+  local -r parser_name="${1:-$C_DEFAULT_PARSER_NAME}"
+  echo "tmp/c/${parser_name}_parser"
+}
+
+display_c_ast() {
+  local -r parser_name="${1:-$C_DEFAULT_PARSER_NAME}"
+  "$(c_parser_dir "$parser_name")/display_ast"
+}

--- a/test/bin/test-c
+++ b/test/bin/test-c
@@ -1,6 +1,22 @@
 #!/bin/bash
 source "${BASH_SOURCE%/*}/env.sh"
+source "${BASH_SOURCE%/*}/lib-c.sh"
 
-cd src/c
-make -s lib
-make -s test
+rm -rf tmp/c
+make -s --directory=src/c lib
+make -s --directory=src/c test
+
+test_output_contains() {
+  local -r parser_name="$1"
+  local -r input="$2"
+  local -r expected="$3"
+  local -r output="$(display_c_ast "$parser_name" <<< "$input")"
+  if ! grep "$expected" <<< "$output" > /dev/null; then
+    printf "Error:\n    input: ${input}\n expected: ${expected}\n   output: ${output}\n"
+    return 1
+  fi
+}
+
+build_c_parser grammars/calc.waxeye calc
+test_output_contains calc '1 + 2' 'calc'
+test_output_contains calc 'x' 'parse error'


### PR DESCRIPTION
Adds a very basic end-to-end test for the C runtime.

Eventually, all runtimes should be able to output the AST to the same format so that we can reuse test fixtures. But for now this provides at least some coverage.