### PR TITLE
TypeScript Parser: Minor enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ clean-compiler:
 # Build runtimes
 .PHONY: runtimes clean-runtimes
 runtimes: runtime-javascript runtime-rubygem runtime-java
-clean-runtimes: clean-runtime-rubygem clean-runtime-java
+clean-runtimes: clean-runtime-javascript clean-runtime-rubygem clean-runtime-java
 
 # Runtimes
-.PHONY: runtime-javascript
+.PHONY: runtime-javascript clean-runtime-javascript
 runtime-javascript: src/javascript/dist/waxeye.js src/waxeye/javascript.rkt
 src/javascript/dist/waxeye.js: src/javascript/*.ts | src/javascript/node_modules
 	cd src/javascript/ && npm run --silent compile
@@ -47,6 +47,8 @@ src/javascript/dist/waxeye.js: src/javascript/*.ts | src/javascript/node_modules
 src/javascript/node_modules: \
   src/javascript/package.json src/javascript/package-lock.json
 	cd src/javascript/ && npm install && touch node_modules
+clean-runtime-javascript:
+	rm -rf src/javascript/dist/
 
 .PHONY: runtime-rubygem clean-runtime-rubygem
 runtime-rubygem: lib/waxeye-$(VERSION).gem

--- a/src/javascript/tslint.json
+++ b/src/javascript/tslint.json
@@ -13,6 +13,7 @@
     "no-duplicate-switch-case": true,
     "interface-name": [true, "never-prefix"],
     "max-classes-per-file": false,
+    "no-unused-variable": true,
     "object-literal-sort-keys": false
   },
   "rulesDirectory": []

--- a/src/waxeye/javascript.rkt
+++ b/src/waxeye/javascript.rkt
@@ -153,11 +153,12 @@
   (let ((parser-name (if *name-prefix*
                          (string-append (camel-case-upper *name-prefix*) "Parser")
                          "Parser")))
-    (format "
+    (format "~a
 import {
   ExprType, ExprAlt, ExprCharClass, ExprSeq,
   NonTerminalMode, ParserConfig, WaxeyeParser
 } from 'waxeye';
+
 const parserConfig: ParserConfig =
  ~a~a~a;
 const start = '~a';
@@ -168,6 +169,9 @@ export class ~a extends WaxeyeParser {
   }
 }
 "
+            (if *file-header*
+              (javascript-comment *file-header*)
+              (javascript-comment *default-header*))
             (ind) (ind) (parameterize ([typescript #t]) (gen-defs grammar))
             *start-name*
             parser-name)))
@@ -207,10 +211,10 @@ if (typeof module !== 'undefined') {
 }
 " (ind) parser-name parser-name)))
 
-(format "~a~a~a~a"
-        (if *file-header*
-            (javascript-comment *file-header*)
-            (javascript-comment *default-header*))
-        (gen-nodejs-imports)
-        (gen-parser-class)
-        (gen-nodejs-exports))))
+    (format "~a~a~a~a"
+      (if *file-header*
+          (javascript-comment *file-header*)
+          (javascript-comment *default-header*))
+      (gen-nodejs-imports)
+      (gen-parser-class)
+      (gen-nodejs-exports))))

--- a/test/javascript/lib.ts
+++ b/test/javascript/lib.ts
@@ -115,19 +115,6 @@ function exprTypeFromName(name: string): waxeye.ExprType {
   return result;
 }
 
-const NAME_TO_NT_MODE: {[key: string]: waxeye.NonTerminalMode} = {
-  NORMAL: waxeye.NonTerminalMode.NORMAL,
-  PRUNING: waxeye.NonTerminalMode.PRUNING,
-  VOIDING: waxeye.NonTerminalMode.VOIDING,
-};
-function nonTerminalModeFromName(name: string): waxeye.NonTerminalMode {
-  const result = NAME_TO_NT_MODE[name];
-  if (!result) {
-    throw new Error(`Unknown NonTerminalMode ${name}`);
-  }
-  return result;
-}
-
 function fromFixtureExpectationCharClasses(charClasses: string): number;
 function fromFixtureExpectationCharClasses(charClasses: [string, string]):
     [number, number];


### PR DESCRIPTION
* Renames some variables for clarity.
* Removes the `ActionReturn` type and inlines `move` into `match`.
* Adds missing `clean-runtime-javascript` make target.
* Adds an "unused variable" lint.
* Adds the file header to the generated TypeScript parsers.

/cc @jishi9 